### PR TITLE
Add doctor illustration to webpage

### DIFF
--- a/doctor.svg
+++ b/doctor.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <circle cx="100" cy="40" r="20" stroke="black" stroke-width="3" fill="white" />
+  <line x1="100" y1="60" x2="100" y2="130" stroke="black" stroke-width="3" />
+  <line x1="100" y1="80" x2="60" y2="110" stroke="black" stroke-width="3" />
+  <line x1="100" y1="80" x2="140" y2="110" stroke="black" stroke-width="3" />
+  <line x1="100" y1="130" x2="70" y2="170" stroke="black" stroke-width="3" />
+  <line x1="100" y1="130" x2="130" y2="170" stroke="black" stroke-width="3" />
+  <rect x="80" y="90" width="40" height="40" stroke="black" stroke-width="3" fill="white" />
+  <line x1="100" y1="95" x2="100" y2="125" stroke="red" stroke-width="3" />
+  <line x1="87" y1="110" x2="113" y2="110" stroke="red" stroke-width="3" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,6 @@
-<html><body><h1>test</h1></body></html>
+<html>
+  <body>
+    <h1>test</h1>
+    <img src="doctor.svg" alt="Illustration of a medical doctor" />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Create a simple SVG illustration of a medical doctor
- Display the doctor illustration on the main index page

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('doctor.svg')
print('SVG parsed OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bc2ed168b08329a390c95993adb0a2