### PR TITLE
Convert site for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Dr. Heathwood Website
+
+This repository contains a simple Jekyll site for Dr. Heathwood's family medicine practice. It is ready to be published with [GitHub Pages](https://pages.github.com/).

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+title: "Dr. Heathwood | Family Medicine"
+description: "Compassionate Family Physician"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ page.title | default: site.title }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
+  </head>
+  <body>
+    {{ content }}
+  </body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,38 @@
+body {
+  font-family: Helvetica, Arial, sans-serif;
+  margin: 0;
+  text-align: center;
+  background: #f7f9fb;
+}
+header {
+  background: #ffffff;
+  padding: 60px 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+.portrait {
+  max-width: 200px;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+  margin: 0 auto 20px;
+}
+section {
+  padding: 40px 20px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.cta {
+  display: inline-block;
+  margin-top: 20px;
+  padding: 12px 24px;
+  background: #2e86c1;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+}
+footer {
+  background: #ffffff;
+  padding: 20px;
+  font-size: 0.9em;
+  color: #555;
+}

--- a/index.html
+++ b/index.html
@@ -1,69 +1,15 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Dr. Heathwood | Family Medicine</title>
-    <style>
-      body {
-        font-family: Helvetica, Arial, sans-serif;
-        margin: 0;
-        text-align: center;
-        background: #f7f9fb;
-      }
-      header {
-        background: #ffffff;
-        padding: 60px 20px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      }
-      .portrait {
-        max-width: 200px;
-        height: auto;
-        border-radius: 4px;
-        display: block;
-        margin: 0 auto 20px;
-      }
-      section {
-        padding: 40px 20px;
-        max-width: 600px;
-        margin: 0 auto;
-      }
-      .cta {
-        display: inline-block;
-        margin-top: 20px;
-        padding: 12px 24px;
-        background: #2e86c1;
-        color: white;
-        text-decoration: none;
-        border-radius: 4px;
-      }
-      footer {
-        background: #ffffff;
-        padding: 20px;
-        font-size: 0.9em;
-        color: #555;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <img
-        class="portrait"
-        src="heathwood.png"
-        alt="Portrait of Dr. Heathwood"
-      />
-      <h1>Dr. Heathwood</h1>
-      <p>Compassionate Family Physician</p>
-      <a class="cta" href="mailto:info@drheathwood.example.com"
-        >Book an Appointment</a
-      >
-    </header>
-    <section>
-      <h2>About</h2>
-      <p>
-        Dr. Heathwood provides personalized, comprehensive care for patients of
-        all ages.
-      </p>
-    </section>
-    <footer>&copy; 2023 Dr. Heathwood. All rights reserved.</footer>
-  </body>
-</html>
+---
+layout: default
+title: Dr. Heathwood | Family Medicine
+---
+<header>
+  <img class="portrait" src="{{ '/heathwood.png' | relative_url }}" alt="Portrait of Dr. Heathwood" />
+  <h1>Dr. Heathwood</h1>
+  <p>Compassionate Family Physician</p>
+  <a class="cta" href="mailto:info@drheathwood.example.com">Book an Appointment</a>
+</header>
+<section>
+  <h2>About</h2>
+  <p>Dr. Heathwood provides personalized, comprehensive care for patients of all ages.</p>
+</section>
+<footer>&copy; 2023 Dr. Heathwood. All rights reserved.</footer>


### PR DESCRIPTION
## Summary
- restructure site to use Jekyll layout for GitHub Pages
- extract styling into dedicated stylesheet and add basic config
- add README describing GitHub Pages setup

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc369f0f1483298d0cf323f1a4856e